### PR TITLE
add libssl-dev to fix pip cryptography build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
 		gcc \
 		curl \
 		libffi-dev \
+		libssl-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # get Python drivers MongoDB, Consul, and Manta


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/autopilotpattern/mongodb/pull/1#issuecomment-244594457), libssl-dev is needed for pip install.
