### PR TITLE
Update "containerpilot.json" to assume "consul" if "CONSUL" is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Pass these variables via an `_env` file.
   - `MONGO_SECONDARY_CATCHUP_PERIOD`: the number of seconds that the mongod will wait for an electable secondary to catch up to the primary
   - `MONGO_STEPDOWN_TIME`: the number of seconds to step down the primary, during which time the stepdown member is ineligible for becoming primary
   - `MONGO_ELECTION_TIMEOUT`: after the primary steps down, the amount a tries to check that a new primary has been elected before the node shuts down
+- `CONSUL` (optional): when using `local-compose.yml`, this will default to `consul` (and thus use the DNS provided by Docker), but for deploying on Triton via `docker-compose.yml`, this should be set to [the CNS path of the `consul` service (`consul.svc.XXX...`)](https://docs.joyent.com/public-cloud/network/cns)
 
 Not yet implemented:
 - `MANTA_URL`: the full Manta endpoint URL. (ex. `https://us-east.manta.joyent.com`)

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,5 +1,5 @@
 {
-  "consul": "{{ .CONSUL }}:8500",
+  "consul": "{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}:8500",
   "preStart": "python /usr/local/bin/manage.py",
   "preStop": "python /usr/local/bin/manage.py pre_stop",
   "services": [

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -7,8 +7,6 @@ services:
         mem_limit: 512m
         build: .
         env_file: _env
-        environment:
-            - CONSUL=consul
         ports:
             - 27017
 


### PR DESCRIPTION
This mimics the behavior of the Python code:

    bin/manage.py:19:consul = pyconsul.Consul(host=os.environ.get('CONSUL', 'consul'))

This allows us to remove `CONSUL=consul` from the Compose files, thus allowing for local deploys to assume the correct value, and Triton deploys to use CNS via `_env` to set `CONSUL=...` to an appropriate value.