### PR TITLE
Add consul client as a coprocess to mongo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,14 @@ RUN export CONSUL_VERSION=0.7.2 \
     && mkdir -p /opt/consul/config
 
 # Add ContainerPilot and set its configuration file path
-ENV CONTAINERPILOT_VER 2.0.1
+ENV CONTAINERPILOT_VER 2.7.0
 ENV CONTAINERPILOT file:///etc/containerpilot.json
-RUN export CONTAINERPILOT_CHECKSUM=a4dd6bc001c82210b5c33ec2aa82d7ce83245154 \
-	&& curl -Lso /tmp/containerpilot.tar.gz \
-		"https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VER}/containerpilot-${CONTAINERPILOT_VER}.tar.gz" \
-	&& echo "${CONTAINERPILOT_CHECKSUM}  /tmp/containerpilot.tar.gz" | sha1sum -c \
-	&& tar zxf /tmp/containerpilot.tar.gz -C /usr/local/bin \
-	&& rm /tmp/containerpilot.tar.gz
+RUN export CONTAINERPILOT_CHECKSUM=687f7d83e031be7f497ffa94b234251270aee75b \
+    && curl -Lso /tmp/containerpilot.tar.gz \
+        "https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VER}/containerpilot-${CONTAINERPILOT_VER}.tar.gz" \
+    && echo "${CONTAINERPILOT_CHECKSUM}  /tmp/containerpilot.tar.gz" | sha1sum -c \
+    && tar zxf /tmp/containerpilot.tar.gz -C /usr/local/bin \
+    && rm /tmp/containerpilot.tar.gz
 
 # add stopping timeouts for MongoDB
 ENV MONGO_SECONDARY_CATCHUP_PERIOD 8

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV MONGO_ELECTION_TIMEOUT 30
 COPY etc/* /etc/
 COPY bin/* /usr/local/bin/
 
-# override the parent entrypoint
 ENTRYPOINT ["containerpilot", "mongod"]
 
+# Define CMD so the name of the replicaset can be overridden in the compose file
 CMD ["--replSet=joyent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
 		curl \
 		libffi-dev \
 		libssl-dev \
+                unzip \
 	&& rm -rf /var/lib/apt/lists/*
 
 # get Python drivers MongoDB, Consul, and Manta
@@ -18,6 +19,15 @@ RUN curl -Ls -o get-pip.py https://bootstrap.pypa.io/get-pip.py && \
 		python-Consul==0.4.7 \
 		manta==2.5.0 \
 		mock==2.0.0
+
+# Add consul agent
+RUN export CONSUL_VERSION=0.7.2 \
+    && export CONSUL_CHECKSUM=aa97f4e5a552d986b2a36d48fdc3a4a909463e7de5f726f3c5a89b8a1be74a58 \
+    && curl --retry 7 --fail -vo /tmp/consul.zip "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \
+    && echo "${CONSUL_CHECKSUM}  /tmp/consul.zip" | sha256sum -c \
+    && unzip /tmp/consul -d /usr/local/bin \
+    && rm /tmp/consul.zip \
+    && mkdir -p /opt/consul/config
 
 # Add ContainerPilot and set its configuration file path
 ENV CONTAINERPILOT_VER 2.0.1
@@ -39,11 +49,6 @@ COPY etc/* /etc/
 COPY bin/* /usr/local/bin/
 
 # override the parent entrypoint
-ENTRYPOINT []
+ENTRYPOINT ["containerpilot", "mongod"]
 
-CMD [ \
-	"containerpilot", \
-	"mongod", \
-	"--replSet=joyent" \
-]
-
+CMD ["--replSet=joyent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:3.2
+FROM mongo:3.4
 
 RUN apt-get update \
 	&& apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN curl -Ls -o get-pip.py https://bootstrap.pypa.io/get-pip.py && \
 		mock==2.0.0
 
 # Add consul agent
-RUN export CONSUL_VERSION=0.7.2 \
-    && export CONSUL_CHECKSUM=aa97f4e5a552d986b2a36d48fdc3a4a909463e7de5f726f3c5a89b8a1be74a58 \
+RUN export CONSUL_VERSION=0.7.5 \
+    && export CONSUL_CHECKSUM=40ce7175535551882ecdff21fdd276cef6eaab96be8a8260e0599fadb6f1f5b8 \
     && curl --retry 7 --fail -vo /tmp/consul.zip "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \
     && echo "${CONSUL_CHECKSUM}  /tmp/consul.zip" | sha256sum -c \
     && unzip /tmp/consul -d /usr/local/bin \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A running cluster includes the following components:
 Starting a new cluster is easy once you have [your `_env` file set with the configuration details](#configuration)
 
 - for Triton, just run `docker-compose up -d`
-- for non-Triton, just run `docker-compose up -f local-compose.yml -d`
+- for non-Triton, just run `docker-compose -f local-compose.yml up -d`
 
 In a few moments you'll have a running MongoDB ready for a replica set. Both the master and replicas are described as a single `docker-compose` service. During startup, [ContainerPilot](http://containerpilot.io) will ask Consul if an existing master has been created. If not, the node will initialize as a new MongoDB replica set and all future nodes will be added to the replica set by the current master. All master election is handled by [MongoDB itself](https://docs.mongodb.com/manual/core/replica-set-elections/) and the result is cached in Consul.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
     mongodb:
         extends:
@@ -7,6 +7,8 @@ services:
         mem_limit: 4g
         labels:
             - triton.cns.services=mongodb
+        links:
+          - consul:consul
         network_mode: bridge
 
     consul:
@@ -18,4 +20,3 @@ services:
         network_mode: bridge
         dns:
             - 127.0.0.1
-

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,5 +1,5 @@
 {
-  "consul": "{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}:8500",
+  "consul": "localhost:8500",
   "preStart": "python /usr/local/bin/manage.py",
   "preStop": "python /usr/local/bin/manage.py pre_stop",
   "services": [
@@ -16,6 +16,18 @@
       "name": "mongodb-replicaset",
       "poll": 10,
       "onChange": "python /usr/local/bin/manage.py on_change"
+    }
+  ],
+  "coprocesses": [
+    {
+      "command": ["/usr/local/bin/consul", "agent",
+                  "-data-dir=/opt/consul/data",
+                  "-config-dir=/opt/consul/config",
+                  "-rejoin",
+                  "-retry-join", "{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}",
+                  "-retry-max", "10",
+                  "-retry-interval", "10s"],
+      "restarts": "unlimited"
     }
   ]
 }

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -1,27 +1,17 @@
-version: '2'
+version: '2.1'
 services:
     mongodb:
-        image: autopilotpattern/mongodb:latest
-        command: containerpilot mongod --replSet=pilot
+        image: autopilotpattern/mongodb
+        command: --replSet=rs0
         restart: always
         mem_limit: 512m
         build: .
-        env_file: _env
         ports:
             - 27017
 
     consul:
-        image: consul:v0.6.4
-        command: agent -dev -ui -client=0.0.0.0
-        restart: always
-        mem_limit: 128m
-        ports:
-            - 8500:8500
-        expose:
-            - 53
-            - 8300
-            - 8301
-            - 8302
-            - 8400
-            - 8500
-
+      image: consul:0.7.2
+      command: agent -server -client=0.0.0.0 -bootstrap -ui
+      ports:
+        - "8500:8500"
+      restart: always

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -10,7 +10,7 @@ services:
             - 27017
 
     consul:
-      image: consul:0.7.2
+      image: consul:0.7.5
       command: agent -server -client=0.0.0.0 -bootstrap -ui
       ports:
         - "8500:8500"


### PR DESCRIPTION
Hello,
I started to embed Consul client in mongodb container as a co-process of mongod.
I'm still working on a problem with the connection to the local consul though.
````
mongodb_1  | Service not registered, registering...
mongodb_1  | 2017/03/06 14:34:40 Service registration failed: Put http://localhost:8500/v1/agent/service/register: dial tcp [::1]:8500: getsockopt: connection refused
````
Regards,
Luc
